### PR TITLE
Added Rewrite Rules for the collectins and portals schemas

### DIFF
--- a/conf/01-ontologies.conf
+++ b/conf/01-ontologies.conf
@@ -20,5 +20,5 @@ ProxyPassReverse "provone/2015/01/15/ontology" "https://raw.githubusercontent.co
 RewriteRule provone-v1-dev  "http://jenkins-1.dataone.org/jenkins/view/Documentation Projects/job/ProvONE-Documentation-trunk/ws/provenance/ProvONE/v1/provone.html" [R=302,L]
 
 ## Collections and Portals
-RewriteRule "collections-1.0.0(.*)" "https://raw.githubusercontent.com/NCEAS/project-papers/1.0.0/schemas/collections.xsd$1" [R=302,L]
-RewriteRule "portals-1.0.0(.*)" "https://raw.githubusercontent.com/NCEAS/project-papers/1.0.0/schemas/portals.xsd$1" [R=302,L]
+RewriteRule "collections-1.0.0(.*)" "https://raw.githubusercontent.com/DataONEorg/collections-portals-schemas/1.0.0/schemas/collections.xsd$1" [R=302,L]
+RewriteRule "portals-1.0.0(.*)" "https://raw.githubusercontent.com/DataONEorg/collections-portals-schemas/1.0.0/schemas/portals.xsd$1" [R=302,L]

--- a/conf/01-ontologies.conf
+++ b/conf/01-ontologies.conf
@@ -18,3 +18,7 @@ RewriteRule ontologies(.*)  https://raw.githubusercontent.com/DataONEorg/sem-pro
 RewriteRule "provone/2015/01/15/ontology(.*)" "https://raw.githubusercontent.com/DataONEorg/sem-prov-ontologies/master/provenance/ProvONE/v1/owl/provone.owl$1" [P]
 ProxyPassReverse "provone/2015/01/15/ontology" "https://raw.githubusercontent.com/DataONEorg/sem-prov-ontologies/master/provenance/ProvONE/v1/owl/provone.owl"
 RewriteRule provone-v1-dev  "http://jenkins-1.dataone.org/jenkins/view/Documentation Projects/job/ProvONE-Documentation-trunk/ws/provenance/ProvONE/v1/provone.html" [R=302,L]
+
+## Collections and Portals
+RewriteRule "collections-1.0.0(.*)" "https://raw.githubusercontent.com/NCEAS/project-papers/1.0.0/schemas/collections.xsd$1" [R=302,L]
+RewriteRule "portals-1.0.0(.*)" "https://raw.githubusercontent.com/NCEAS/project-papers/1.0.0/schemas/portals.xsd$1" [R=302,L]

--- a/www/index.html
+++ b/www/index.html
@@ -25,7 +25,9 @@ var purls=[
   ['https://purl.dataone.org/odo',''],
   ['https://purl.dataone.org/ontologies','Base of ontology references for DataONE.'],
   ['https://purl.dataone.org/WBS','Work breakdown structure for DataONE project, phase 2.'],
-  ['https://purl.dataone.org/provone-v1-dev','ProvONE provenance ontology.']
+  ['https://purl.dataone.org/provone-v1-dev','ProvONE provenance ontology.'],
+  ['https://purl.dataone.org/collections-1.0.0','DataONE collections schema.'],
+  ['https://purl.dataone.org/portals-1.0.0','DataONE portals schema.']
 ];
 
 function parseURL(url) {


### PR DESCRIPTION
Added two new RewriteRules for the Collections and Portals 1.0.0 XML schemas. These need to be in place for the next Metacat and Dataone CI releases so that the collections and portals objects can be inserted into Metacat and synced with DataONE. This is required for the new portal editor feature in MetacatUI to work.