### PR TITLE
Add conf directive for ARCRC redirection

### DIFF
--- a/conf/01-ontologies.conf
+++ b/conf/01-ontologies.conf
@@ -4,6 +4,10 @@
 RewriteRule obo/ECSO_(.*)    http://bioportal.bioontology.org/ontologies/ECSO/?p=classes&conceptid=http://purl.dataone.org/obo/ECSO_$1 [R=302,L]
 RewriteRule odo/ECSO_(.*)    http://bioportal.bioontology.org/ontologies/ECSO/?p=classes&conceptid=http://purl.dataone.org/odo/ECSO_$1 [R=302,L]
 
+# ARCRC ontology
+# https://github.com/DataONEorg/sem-prov-ontologies/tree/master/arctic-report-card
+RewriteRule odo/ARCRC_(.*)    https://bioportal.bioontology.org/ontologies/ARCRC/?p=classes&conceptid=http://purl.dataone.org/odo/ARCRC_$1 [R=302,L]
+
 ## branches
 RewriteRule obo/(.*)    https://raw.githubusercontent.com/DataONEorg/sem-prov-ontologies/run4/observation/$1 [R=302,L]
 RewriteRule odo/(.*)    https://raw.githubusercontent.com/DataONEorg/sem-prov-ontologies/run4/observation/$1 [R=302,L]


### PR DESCRIPTION
Ref https://github.com/DataONEorg/dataone_purl/issues/2
Ref https://github.com/DataONEorg/sem-prov-ontologies/issues/56

- I only add a redirect for `odo` and not `obo` since we don't use that pattern in the ARCRC URI space
- I put it in what I think is the right position in the config, just above the wild card `obo/(.*)` rule and with a `[L]` rewrite flag
- I didn't update anything in index.html because we haven't been putting things like this there

I'm more than happy to deploy the change if I can be given access to the host. Let me know.