### PR TITLE
Add redirects for ECSO itself to 01-ontologies.owl

### DIFF
--- a/conf/01-ontologies.conf
+++ b/conf/01-ontologies.conf
@@ -1,8 +1,10 @@
 # PURLs for ontologies used by DataONE and related tools 
 #
 ## ECSO ontology
-RewriteRule obo/ECSO_(.*)    http://bioportal.bioontology.org/ontologies/ECSO/?p=classes&conceptid=http://purl.dataone.org/obo/ECSO_$1 [R=302,L]
-RewriteRule odo/ECSO_(.*)    http://bioportal.bioontology.org/ontologies/ECSO/?p=classes&conceptid=http://purl.dataone.org/odo/ECSO_$1 [R=302,L]
+RewriteRule obo/ECSO_(.+)    http://bioportal.bioontology.org/ontologies/ECSO/?p=classes&conceptid=http://purl.dataone.org/obo/ECSO_$1 [R=302,L]
+RewriteRule odo/ECSO_(.+)    http://bioportal.bioontology.org/ontologies/ECSO/?p=classes&conceptid=http://purl.dataone.org/odo/ECSO_$1 [R=302,L]
+RewriteRule ^/obo/ECSO_?$    http://bioportal.bioontology.org/ontologies/ECSO/ [R=302,L]
+RewriteRule ^/odo/ECSO_?$    http://bioportal.bioontology.org/ontologies/ECSO/ [R=302,L]
 
 # ARCRC ontology
 # https://github.com/DataONEorg/sem-prov-ontologies/tree/master/arctic-report-card


### PR DESCRIPTION
Redirects /o{d,b}o/ECSO_.+ to a BioPortal page for that term and /o{d,b}o/ECSO_? to the main BioPortal page. Tested on Apache 2.4.29.

Closes https://github.com/DataONEorg/dataone_purl/issues/6.

I wanna hold off on merging and deploying this until folks have had a chance to comment on https://github.com/DataONEorg/dataone_purl/issues/6 and/or https://github.com/DataONEorg/sem-prov-ontologies/issues/90.