### PR TITLE
Add redirects in for MOSAiC ontology URIs

### DIFF
--- a/conf/01-ontologies.conf
+++ b/conf/01-ontologies.conf
@@ -10,6 +10,12 @@ RewriteRule ^/odo/ECSO_?$    http://bioportal.bioontology.org/ontologies/ECSO/ [
 # https://github.com/DataONEorg/sem-prov-ontologies/tree/master/arctic-report-card
 RewriteRule odo/ARCRC_(.*)    https://bioportal.bioontology.org/ontologies/ARCRC/?p=classes&conceptid=http://purl.dataone.org/odo/ARCRC_$1 [R=302,L]
 
+# MOSAiC Ontology
+# https://github.com/DataONEorg/sem-prov-ontologies/
+RewriteRule ^/odo/MOSAIC_?$ "https://dataoneorg.github.io/sem-prov-ontologies/MOSAiC.html" [R=302,L]
+RewriteRule ^/odo/MOSAIC_(.+)$ "https://dataoneorg.github.io/sem-prov-ontologies/MOSAiC.html#https://purl.dataone.org/odo/MOSAIC_$1" [R=302,L,NE]
+RewriteRule ^/odo/MOSAIC/1.0.0/?$ "https://raw.githubusercontent.com/DataONEorg/sem-prov-ontologies/mosaic-1.0.0/MOSAiC/MOSAiC.owl" [R=302,L]
+
 ## branches
 RewriteRule obo/(.*)    https://raw.githubusercontent.com/DataONEorg/sem-prov-ontologies/run4/observation/$1 [R=302,L]
 RewriteRule odo/(.*)    https://raw.githubusercontent.com/DataONEorg/sem-prov-ontologies/run4/observation/$1 [R=302,L]


### PR DESCRIPTION
Closes https://github.com/DataONEorg/dataone_purl/issues/8

Tested redirects using a local Apache setup and everything looks good. These all redirect to our [proof-of-concept ontologies page](https://github.com/DataONEorg/sem-prov-ontologies/issues/98) so this might need an update in the future.